### PR TITLE
Fix color leakage in current-player state encoding

### DIFF
--- a/davechess/engine/network.py
+++ b/davechess/engine/network.py
@@ -4,7 +4,7 @@ Input: 18 planes of 8x8
   Planes 0-4: Current player's C/W/R/B/L positions (binary)
   Planes 5-9: Opponent's C/W/R/B/L positions (binary)
   Plane 10: Gold node positions (binary)
-  Plane 11: Current player indicator (all 1s or 0s)
+  Plane 11: Side-to-move indicator (all 1s)
   Plane 12: Current player resources (scalar broadcast, normalized)
   Plane 13: Opponent resources (scalar broadcast, normalized)
   Plane 14: Turn progress (turn/100, broadcast — urgency signal)
@@ -84,8 +84,14 @@ def state_to_planes(state: GameState) -> np.ndarray:
     for r, c in GOLD_NODES:
         planes[10, r, c] = 1.0
 
-    # Current player indicator
-    planes[11, :, :] = 1.0 if current == Player.WHITE else 0.0
+    # Side-to-move indicator.
+    #
+    # With current-player-relative encoding (planes 0-9 + optional flip),
+    # side to move is always "self". Encoding absolute color here (white=1,
+    # black=0) leaks an irrelevant color bit that breaks symmetry: identical
+    # tactical patterns from opposite colors no longer map to identical input.
+    # Keep this plane constant so representation stays color-invariant.
+    planes[11, :, :] = 1.0
 
     # Resources (normalized, broadcast)
     planes[12, :, :] = min(state.resources[current] / RESOURCE_NORM, 1.0)

--- a/tests/test_board_flipping.py
+++ b/tests/test_board_flipping.py
@@ -69,16 +69,16 @@ class TestBoardFlipPlanes:
         gold_black = set(zip(*np.where(planes_black[10] > 0)))
         assert gold_white == gold_black
 
-    def test_player_indicator_preserved(self):
-        """Player indicator plane should be 1 for White, 0 for Black."""
+    def test_side_to_move_plane_is_constant(self):
+        """Side-to-move plane should remain constant in current-player frame."""
         state = GameState()
         planes_w = state_to_planes(state)
-        assert planes_w[11, 0, 0] == 1.0  # White
+        assert np.all(planes_w[11] == 1.0)
 
         legal = generate_legal_moves(state)
         apply_move(state, legal[0])
         planes_b = state_to_planes(state)
-        assert planes_b[11, 0, 0] == 0.0  # Black
+        assert np.all(planes_b[11] == 1.0)
 
     def test_last_move_flipped_for_black(self):
         """Last move source/dest planes should be flipped for Black."""


### PR DESCRIPTION
### Motivation
- Training was underperforming due to a subtle representation bug: the side-to-move plane encoded absolute color (`white=1, black=0`) while the rest of the input tensor is already in a current-player-relative frame, leaking an irrelevant color bit and breaking color symmetry for equivalent positions.

### Description
- In `state_to_planes()` set the side-to-move plane (`plane 11`) to a constant `1.0` instead of encoding absolute color so inputs are color-invariant in the current-player frame (file: `davechess/engine/network.py`).
- Updated the header/docs in `network.py` to reflect the new semantics for `plane 11`.
- Adjusted tests in `tests/test_board_flipping.py` to assert that the side-to-move plane is constant for both White and Black turns.

### Testing
- Ran `pytest -q tests/test_board_flipping.py` which passed (`31 passed`).
- Performed a quick sanity check with a short Python script verifying `plane 11` is `1.0` for both White-to-move and Black-to-move states (succeeded).
- Attempted a combined run including `tests/test_regularization.py`, but that run failed in this environment due to missing `torch` (resulting in `ImportError`/`ModuleNotFoundError` for `DaveChessNetwork` / `torch`), not related to the changed encoding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4447f83ac83329ecbf722538c53b6)